### PR TITLE
Fix dashboard template not found error

### DIFF
--- a/routes/admin_routes.py
+++ b/routes/admin_routes.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, flash
 from models import db, User
 from flask_login import login_required, current_user
 
-admin_bp = Blueprint('admin', __name__, template_folder='templates/admin')
+admin_bp = Blueprint('admin', __name__, template_folder='../templates/admin', static_folder='../static')
 
 # Dashboard (محمي ويعرض البنوك والشركات)
 @admin_bp.route('/dashboard')


### PR DESCRIPTION
Correct `template_folder` path for the admin blueprint to resolve `TemplateNotFound` error.

---
<a href="https://cursor.com/background-agent?bcId=bc-54822ec4-51af-4a13-ab36-b2e2f6206688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-54822ec4-51af-4a13-ab36-b2e2f6206688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

