### PR TITLE
Fix duplicate content block definition

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -301,17 +301,3 @@
     </div>
 
 {% endblock %}
-
-{% extends 'layout.html' %}
-{% block content %}
-  <div class="text-center">
-    <h1>Welcome to Valuation Platform</h1>
-    <p class="lead">Use one of the portals:</p>
-    <div class="d-flex justify-content-center gap-2">
-      <a class="btn btn-primary" href="/client/login">Client Portal</a>
-      <a class="btn btn-secondary" href="/admin/dashboard">Admin Portal</a>
-      <a class="btn btn-success" href="/company/dashboard">Company Portal</a>
-      <a class="btn btn-info" href="/bank/dashboard">Bank Portal</a>
-    </div>
-  </div>
-{% endblock %}


### PR DESCRIPTION
Remove duplicate `{% extends %}` and `{% block content %}` in `templates/index.html` to resolve `TemplateAssertionError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-42070fa6-5f2a-4476-9724-de9deec4021e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-42070fa6-5f2a-4476-9724-de9deec4021e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

