### PR TITLE
Filter approved banks for company profile

### DIFF
--- a/templates/companies/detail.html
+++ b/templates/companies/detail.html
@@ -26,17 +26,31 @@
 
     <div class="mb-3">
       <h4 class="h6">البنوك المعتمدة لدى الشركة</h4>
-      {% if company.company_profile and company.company_profile.approved_banks %}
-      <ul class="list-group">
-        {% for ab in company.company_profile.approved_banks %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          <span>{{ ab.bank_user.name }}{% if ab.bank_user.phone %} — {{ ab.bank_user.phone }}{% endif %}</span>
-          <span class="badge bg-secondary">{% if ab.limit_value %}{{ ab.limit_value }} OMR{% else %}-{% endif %}</span>
-        </li>
-        {% endfor %}
-      </ul>
+      {% set profile = company.company_profile %}
+      {% if profile %}
+        {% if profile.approved_banks and profile.approved_banks|length > 0 %}
+          <ul class="list-group">
+            {% for ab in profile.approved_banks %}
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+              <span>{{ ab.bank_user.name }}{% if ab.bank_user.phone %} — {{ ab.bank_user.phone }}{% endif %}</span>
+              <span class="badge bg-secondary">{% if ab.limit_value %}{{ ab.limit_value }} OMR{% else %}-{% endif %}</span>
+            </li>
+            {% endfor %}
+          </ul>
+        {% elif profile.manual_banks and profile.manual_banks|length > 0 %}
+          <ul class="list-group">
+            {% for mb in profile.manual_banks %}
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+              <span>{{ mb.name }}{% if mb.phone %} — {{ mb.phone }}{% elif mb.email %} — {{ mb.email }}{% endif %}</span>
+              <span class="badge bg-secondary">{% if mb.limit_value %}{{ mb.limit_value }} OMR{% else %}-{% endif %}</span>
+            </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p>-</p>
+        {% endif %}
       {% else %}
-      <p>-</p>
+        <p>-</p>
       {% endif %}
     </div>
 


### PR DESCRIPTION
Display manual banks from `company/profile` on the company detail page (`/companies/:id`) when no `CompanyApprovedBank` entries exist.

This change ensures that banks entered manually in the company profile are shown as approved banks on the company detail page, providing a fallback when no formally approved bank accounts are linked. The display logic prioritizes `approved_banks`, then `manual_banks`, and finally shows a dash if neither is present.

---
<a href="https://cursor.com/background-agent?bcId=bc-b773208f-282f-421a-bee6-09efa05e779a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b773208f-282f-421a-bee6-09efa05e779a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

